### PR TITLE
Improve type for CreationContextFactory::alwaysValidate

### DIFF
--- a/src/Support/Creation/CreationContextFactory.php
+++ b/src/Support/Creation/CreationContextFactory.php
@@ -87,6 +87,9 @@ class CreationContextFactory
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function alwaysValidate(): self
     {
         $this->validationStrategy = ValidationStrategy::Always;


### PR DESCRIPTION
Improve type for `\Spatie\LaravelData\Support\Creation\CreationContextFactory::alwaysValidate()` function

Without explicitly returning `$this` type, the current definition loses generic information. 
https://phpstan.org/r/1b074136-57c7-4f4e-a2ec-34fd1e9bfd91

```php
  $factory = MentionableRecord::factory()->alwaysValidate();
  \PHPStan\dumpType($factory);
```
Current state 
 > Dumped type: Spatie\LaravelData\Support\Creation\CreationContextFactory

After the change
 > Dumped type: Spatie\LaravelData\Support\Creation\CreationContextFactory<App\Dto\MentionableRecord>